### PR TITLE
Ensure :latest points to the latest and greatest, not the newest

### DIFF
--- a/scripts/push_to_docker_hub.sh
+++ b/scripts/push_to_docker_hub.sh
@@ -1,11 +1,28 @@
 #!/bin/bash
 
-TAG=$1
-if [ "${TAG}" == "" ]; then
-    TAG="fedora"
+set -e
+
+push_tag() {
+    local tag="monetdb/monetdb:$1"
+    echo "pushing $tag"
+    docker push "$tag"
+}
+
+
+tag="${1?Usage: $0 TAG}"
+
+# Recognize tags of the form Sep2022 and Sep2022-stuff
+series="$(<<<"$tag" sed -n -e 's,^\([A-Z][a-z][a-z][0-9][0-9][0-9][0-9]\).*,\1,p')"
+
+# Always push the tag itself
+push_tag $tag
+
+# If it's of the form Sep2022 or Sep2022-SP1, push 'Sep2022-latest'
+if [[ -n "$series" ]]; then
+    push_tag "$series-latest"
 fi
 
-echo "pushing monetdb/monetdb:${TAG} ..."
-
-docker push monetdb/monetdb:${TAG}
-docker push monetdb/monetdb:latest
+# If it's of the form Sep2022, push 'latest'
+if [[ -n "$series" && "$tag" = "$series" ]]; then
+    push_tag "latest"
+fi


### PR DESCRIPTION
The old script used to update the 'monetdb/monetdb:latest' tag on every push.  This means that one day 'monetdb/monetdb:latest' might point to 'monetdb/monetdb:Sep2022-SP1' and the next day it could point to 'monetdb/monetdb:Jan2020-SP7'.

Users expect the :latest tag to point to the latest and greatest, most suitable release, not the most recently released version.

When invoked with tag 'banana', this script pushes
	monetdb/monetdb:banana

When invoked with tag 'Feb2023', this script pushes
	monetdb/monetdb:Feb2023
	monetdb/monetdb:Feb2023-latest
	monetdb/monetdb:latest

When invoked with tag 'Feb2023-SP1', this script pushes
	monetdb/monetdb:Feb2023-SP1
	monetdb/monetdb:Feb2023-latest

(and not monetdb/monetdb:latest)